### PR TITLE
Corrige erro ao salvar histórico pela primeira vez

### DIFF
--- a/main.py
+++ b/main.py
@@ -83,7 +83,7 @@ def save_history(anime, episode):
             dump(data, f)
 
     except FileNotFoundError:
-        Path(file_path).mkdir(parents=True, exist_ok=True)
+        Path(HISTORY_PATH).mkdir(parents=True, exist_ok=True)
 
         with open(file_path, "w") as f:
             data = dict()


### PR DESCRIPTION
## Problema
Ao usar o ani-tupi pela primeira vez, a aplicação trava após fechar o mpv com um erro `IsADirectoryError`.

### Causa Raiz
Na função `save_history()` (linha 86), quando o arquivo `history.json` não existe, o código tenta criar um diretório usando o **caminho do arquivo** ao invés do **caminho do diretório**:

```python
Path(file_path).mkdir(parents=True, exist_ok=True)  # Errado!
```

Isso cria um **diretório** chamado `history.json` ao invés de criar o diretório pai e depois o arquivo.

## Solução
Alterada a linha para criar corretamente o diretório pai:

```python
Path(HISTORY_PATH).mkdir(parents=True, exist_ok=True)  # Correto!
```

Agora o código:
1. Cria o diretório `~/.local/state/ani-tupi/` se não existir
2. Cria o arquivo `history.json` dentro dele
3. Salva o histórico de visualização com sucesso

## Testes
- Testado com instalação nova (sem histórico existente)
- Histórico agora é salvo corretamente após assistir um episódio
- Não ocorre mais o erro `IsADirectoryError` ao fechar o mpv